### PR TITLE
Supported image v1.13.0

### DIFF
--- a/changelog/v2.0.md
+++ b/changelog/v2.0.md
@@ -5,6 +5,12 @@ All notable changes to this project for v2.0.Z will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.0.2] - 2021-12-07
+
+### Changed
+
+- supported image v1.13.0
+
 ## [2.0.1] - 2021-12-01
 
 ### Changed

--- a/charts/v2.0/cray-hms-bss/Chart.yaml
+++ b/charts/v2.0/cray-hms-bss/Chart.yaml
@@ -12,6 +12,6 @@ dependencies:
 maintainers:
   - name: Hardware Management
     url: https://github.com/orgs/Cray-HPE/teams/hardware-management
-appVersion: "1.12.0"
+appVersion: "1.13.0"
 annotations:
   artifacthub.io/license: "MIT"

--- a/charts/v2.0/cray-hms-bss/values.yaml
+++ b/charts/v2.0/cray-hms-bss/values.yaml
@@ -11,7 +11,7 @@
 # See https://connect.us.cray.com/jira/browse/CASMCLOUD-661
 
 global:
-  appVersion: 1.12.0
+  appVersion: 1.13.0
 
 image:
   repository: artifactory.algol60.net/csm-docker/stable/cray-bss

--- a/cray-hms-bss.compatibility.yaml
+++ b/cray-hms-bss.compatibility.yaml
@@ -11,6 +11,7 @@ chartVersionToApplicationVersion:
   # Chart version: Application version
   "2.0.0": "1.11.0"
   "2.0.1": "1.12.0"
+  "2.0.2": "1.13.0"
 
 # Test results for combinations of Chart, Application, and CSM versions.  
 chartValidationLog: []


### PR DESCRIPTION
## Summary and Scope

Adds support to BSS for NCN automation specifically endpoint access history.

## Issues and Related PRs

CASMINST-3440

## Testing

Tested extensively on Mug.

Test description:

Put the new service in place and did rebuilds verifying correct data in BSS.


## Risks and Mitigations

None, all new.

Requires: https://github.com/Cray-HPE/hms-bss/pull/36


## Pull Request Checklist

- [X ] Version number(s) incremented, if applicable
- [X ] Copyrights updated
- [X ] License file intact
- [X ] Target branch correct
- [X ] CHANGELOG.md updated
- [X ] Testing is appropriate and complete, if applicable