### PR TITLE
Changed to use image v1.14.0

### DIFF
--- a/changelog/v2.0.md
+++ b/changelog/v2.0.md
@@ -5,6 +5,12 @@ All notable changes to this project for v2.0.Z will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.0.3] - 2021-12-14
+
+### Changed
+
+- supported image v1.14.0
+
 ## [2.0.2] - 2021-12-07
 
 ### Changed

--- a/charts/v2.0/cray-hms-bss/Chart.yaml
+++ b/charts/v2.0/cray-hms-bss/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: "cray-hms-bss"
-version: 2.0.2
+version: 2.0.3
 description: "Kubernetes resources for cray-hms-bss"
 home: "https://github.com/Cray-HPE/hms-bss-charts"
 sources:
@@ -12,6 +12,6 @@ dependencies:
 maintainers:
   - name: Hardware Management
     url: https://github.com/orgs/Cray-HPE/teams/hardware-management
-appVersion: "1.13.0"
+appVersion: "1.14.0"
 annotations:
   artifacthub.io/license: "MIT"

--- a/charts/v2.0/cray-hms-bss/values.yaml
+++ b/charts/v2.0/cray-hms-bss/values.yaml
@@ -11,7 +11,7 @@
 # See https://connect.us.cray.com/jira/browse/CASMCLOUD-661
 
 global:
-  appVersion: 1.13.0
+  appVersion: 1.14.0
 
 image:
   repository: artifactory.algol60.net/csm-docker/stable/cray-bss

--- a/cray-hms-bss.compatibility.yaml
+++ b/cray-hms-bss.compatibility.yaml
@@ -12,6 +12,7 @@ chartVersionToApplicationVersion:
   "2.0.0": "1.11.0"
   "2.0.1": "1.12.0"
   "2.0.2": "1.13.0"
+  "2.0.3": "1.14.0"
 
 # Test results for combinations of Chart, Application, and CSM versions.  
 chartValidationLog: []


### PR DESCRIPTION
Jira: CASMHMS-4540

## Summary and Scope

Changes the method used to lookup boot parameters by name, mac, and nid. This improves the performance when there a many boot parameter entries. For details see https://github.com/Cray-HPE/hms-bss/pull/41

## Issues and Related PRs

* Resolves CASMHMS-4540
* Merge after https://github.com/Cray-HPE/hms-bss/pull/41

## Testing

Tested on:

  * wasp

Test description: see https://github.com/Cray-HPE/hms-bss/pull/41


## Risks and Mitigations

see https://github.com/Cray-HPE/hms-bss/pull/41

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable