### PR TITLE
Changed to use image v1.15.0

### DIFF
--- a/changelog/v2.0.md
+++ b/changelog/v2.0.md
@@ -5,6 +5,12 @@ All notable changes to this project for v2.0.Z will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.0.5] - 2022-01-31
+
+### Changed
+
+- supported image v1.15.0
+
 ## [2.0.4] - 2022-01-27
 
 ### Changed

--- a/charts/v2.0/cray-hms-bss/Chart.yaml
+++ b/charts/v2.0/cray-hms-bss/Chart.yaml
@@ -12,6 +12,6 @@ dependencies:
 maintainers:
   - name: Hardware Management
     url: https://github.com/orgs/Cray-HPE/teams/hardware-management
-appVersion: "1.14.0"
+appVersion: "1.15.0"
 annotations:
   artifacthub.io/license: "MIT"

--- a/charts/v2.0/cray-hms-bss/values.yaml
+++ b/charts/v2.0/cray-hms-bss/values.yaml
@@ -11,7 +11,7 @@
 # See https://connect.us.cray.com/jira/browse/CASMCLOUD-661
 
 global:
-  appVersion: 1.14.0
+  appVersion: 1.15.0
 
 image:
   repository: artifactory.algol60.net/csm-docker/stable/cray-bss

--- a/cray-hms-bss.compatibility.yaml
+++ b/cray-hms-bss.compatibility.yaml
@@ -14,6 +14,7 @@ chartVersionToApplicationVersion:
   "2.0.2": "1.13.0"
   "2.0.3": "1.14.0"
   "2.0.4": "1.14.0"
+  "2.0.5": "1.15.0"
 
 # Test results for combinations of Chart, Application, and CSM versions.  
 chartValidationLog: []


### PR DESCRIPTION
Jira: CASMHMS-4903

## Summary and Scope

Adopts the BSS change that supports returning Referral Tokens, a UUID.

## Issues and Related PRs

* Resolves CASMHMS-4903
* Merge after https://github.com/Cray-HPE/hms-bss/pull/43
## Testing

see https://github.com/Cray-HPE/hms-bss/pull/43

## Risks and Mitigations

see https://github.com/Cray-HPE/hms-bss/pull/43

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable