### PR TITLE
CASMHMS-5458 Coordination for HMS CT Helm tests

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2021 Cray / HPE
+Copyright (c) [2021-2022] Cray / HPE
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/changelog/v2.1.md
+++ b/changelog/v2.1.md
@@ -1,9 +1,15 @@
 # Changelog for v2.1
 
-All notable changes to this project for v2.0.Z will be documented in this file.
+All notable changes to this project for v2.1.Z will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [2.1.1] - 2022-06-22
+
+### Changed
+
+- updated CT tests to hms-test:3.1.0 image as part of Helm test coordination
 
 ## [2.1.0] - 2022-03-03
 

--- a/charts/v2.1/cray-hms-bss/Chart.yaml
+++ b/charts/v2.1/cray-hms-bss/Chart.yaml
@@ -12,6 +12,6 @@ dependencies:
 maintainers:
   - name: Hardware Management
     url: https://github.com/orgs/Cray-HPE/teams/hardware-management
-appVersion: "1.16.0"
+appVersion: "1.17.0"
 annotations:
   artifacthub.io/license: "MIT"

--- a/charts/v2.1/cray-hms-bss/Chart.yaml
+++ b/charts/v2.1/cray-hms-bss/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: "cray-hms-bss"
-version: 2.1.0
+version: 2.1.1
 description: "Kubernetes resources for cray-hms-bss"
 home: "https://github.com/Cray-HPE/hms-bss-charts"
 sources:

--- a/charts/v2.1/cray-hms-bss/values.yaml
+++ b/charts/v2.1/cray-hms-bss/values.yaml
@@ -12,14 +12,16 @@
 
 global:
   appVersion: 1.16.0
-  testVersion: 1.16.0
+  #testVersion: 1.16.0
+  testVersion: 1.16.0-20220613193618.652a901
 image:
   repository: artifactory.algol60.net/csm-docker/stable/cray-bss
   pullPolicy: IfNotPresent
 tests:
   image:
-    repository: artifactory.algol60.net/csm-docker/stable/cray-bss-test
-    pullPolicy: IfNotPresent
+    #repository: artifactory.algol60.net/csm-docker/stable/cray-bss-test
+    repository: artifactory.algol60.net/csm-docker/unstable/cray-bss-test
+    pullPolicy: Always
 
 ipxe:
   dnsServerIp: "10.2.255.253"

--- a/charts/v2.1/cray-hms-bss/values.yaml
+++ b/charts/v2.1/cray-hms-bss/values.yaml
@@ -11,17 +11,17 @@
 # See https://connect.us.cray.com/jira/browse/CASMCLOUD-661
 
 global:
-  appVersion: 1.16.0
-  #testVersion: 1.16.0
-  testVersion: 1.16.0-20220613193618.652a901
+  appVersion: 1.17.0
+  testVersion: 1.17.0
+
 image:
   repository: artifactory.algol60.net/csm-docker/stable/cray-bss
   pullPolicy: IfNotPresent
+
 tests:
   image:
-    #repository: artifactory.algol60.net/csm-docker/stable/cray-bss-test
-    repository: artifactory.algol60.net/csm-docker/unstable/cray-bss-test
-    pullPolicy: Always
+    repository: artifactory.algol60.net/csm-docker/stable/cray-bss-test
+    pullPolicy: IfNotPresent
 
 ipxe:
   dnsServerIp: "10.2.255.253"

--- a/cray-hms-bss.compatibility.yaml
+++ b/cray-hms-bss.compatibility.yaml
@@ -17,6 +17,7 @@ chartVersionToApplicationVersion:
   "2.0.4": "1.14.0"
   "2.0.5": "1.15.0"
   "2.1.0": "1.16.0"
+  "2.1.1": "1.17.0"
 
 # Test results for combinations of Chart, Application, and CSM versions.  
 chartValidationLog: []


### PR DESCRIPTION
### Summary and Scope

This PR includes the following changes:

- Update CT tests to stable hms-test:3.1.0 image (upgrades pytest and tavern to work around python issue43798)
- Pull Alpine base image from correct location in algol60 artifactory
- CT test cleanup

### Issues and Related PRs

* Partially resolves CASMHMS-5458.

### Testing

This change was tested by deploying the updated version of the service and chart onto Mug, executing the Helm CT tests, and verifying that they passed.

Was a fresh Install tested? N
Was an Upgrade tested? Y
Was a Downgrade tested? N

### Risks and Mitigations

Low risk, test update.