### PR TITLE
Remove HSM v1 references in BSS

### DIFF
--- a/changelog/v2.1.md
+++ b/changelog/v2.1.md
@@ -5,6 +5,12 @@ All notable changes to this project for v2.1.Z will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.1.2] - 2022-06-29
+
+### Removed
+
+- Removed references to HSM v1 API
+
 ## [2.1.1] - 2022-06-22
 
 ### Changed

--- a/charts/v2.1/cray-hms-bss/Chart.yaml
+++ b/charts/v2.1/cray-hms-bss/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: "cray-hms-bss"
-version: 2.1.1
+version: 2.1.2
 description: "Kubernetes resources for cray-hms-bss"
 home: "https://github.com/Cray-HPE/hms-bss-charts"
 sources:
@@ -12,6 +12,6 @@ dependencies:
 maintainers:
   - name: Hardware Management
     url: https://github.com/orgs/Cray-HPE/teams/hardware-management
-appVersion: "1.17.0"
+appVersion: "1.18.0"
 annotations:
   artifacthub.io/license: "MIT"

--- a/charts/v2.1/cray-hms-bss/values.yaml
+++ b/charts/v2.1/cray-hms-bss/values.yaml
@@ -11,8 +11,8 @@
 # See https://connect.us.cray.com/jira/browse/CASMCLOUD-661
 
 global:
-  appVersion: 1.17.0
-  testVersion: 1.17.0
+  appVersion: 1.18.0
+  testVersion: 1.18.0
 
 image:
   repository: artifactory.algol60.net/csm-docker/stable/cray-bss

--- a/cray-hms-bss.compatibility.yaml
+++ b/cray-hms-bss.compatibility.yaml
@@ -18,6 +18,7 @@ chartVersionToApplicationVersion:
   "2.0.5": "1.15.0"
   "2.1.0": "1.16.0"
   "2.1.1": "1.17.0"
+  "2.1.2": "1.18.0"
 
 # Test results for combinations of Chart, Application, and CSM versions.  
 chartValidationLog: []


### PR DESCRIPTION
## Summary and Scope

Update BSS image version for the removal of HSM v1 references

## Issues and Related PRs

* Resolves [CASMHMS-5543](https://jira-pro.its.hpecorp.net:8443/browse/CASMHMS-5543)

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable