### PR TITLE
CASMHMS-5612 Helm CT test enhancements and CVE remediation

### DIFF
--- a/changelog/v2.1.md
+++ b/changelog/v2.1.md
@@ -5,6 +5,12 @@ All notable changes to this project for v2.1.Z will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.1.3] - 2022-07-20
+
+### Changed
+
+- Updated CT tests to hms-test:3.2.0 image to pick up Helm test enhancements and CVE fixes
+
 ## [2.1.2] - 2022-06-29
 
 ### Removed
@@ -15,10 +21,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- updated CT tests to hms-test:3.1.0 image as part of Helm test coordination
+- Updated CT tests to hms-test:3.1.0 image as part of Helm test coordination
 
 ## [2.1.0] - 2022-03-03
 
 ### Added
 
-- added functional and smoke helm tests. 
+- Added functional and smoke helm tests

--- a/charts/v2.1/cray-hms-bss/Chart.yaml
+++ b/charts/v2.1/cray-hms-bss/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: "cray-hms-bss"
-version: 2.1.2
+version: 2.1.3
 description: "Kubernetes resources for cray-hms-bss"
 home: "https://github.com/Cray-HPE/hms-bss-charts"
 sources:
@@ -12,6 +12,6 @@ dependencies:
 maintainers:
   - name: Hardware Management
     url: https://github.com/orgs/Cray-HPE/teams/hardware-management
-appVersion: "1.18.0"
+appVersion: "1.19.0"
 annotations:
   artifacthub.io/license: "MIT"

--- a/charts/v2.1/cray-hms-bss/values.yaml
+++ b/charts/v2.1/cray-hms-bss/values.yaml
@@ -11,8 +11,8 @@
 # See https://connect.us.cray.com/jira/browse/CASMCLOUD-661
 
 global:
-  appVersion: 1.18.0
-  testVersion: 1.18.0
+  appVersion: 1.19.0
+  testVersion: 1.19.0
 
 image:
   repository: artifactory.algol60.net/csm-docker/stable/cray-bss

--- a/cray-hms-bss.compatibility.yaml
+++ b/cray-hms-bss.compatibility.yaml
@@ -19,6 +19,7 @@ chartVersionToApplicationVersion:
   "2.1.0": "1.16.0"
   "2.1.1": "1.17.0"
   "2.1.2": "1.18.0"
+  "2.1.3": "1.19.0"
 
 # Test results for combinations of Chart, Application, and CSM versions.  
 chartValidationLog: []


### PR DESCRIPTION
### Summary and Scope

This PR includes the following changes for the Helm CT tests:

- kill the istio sidecar after the tests run to save wait time
- remove build dependencies from final test image that aren't needed to run the tests
- revert the test base image to alpine:3.15 to resolve CVEs

### Issues and Related PRs

* Partially resolves CASMHMS-5612.

### Testing

This change was tested by deploying a new version of an HMS service on Mug which pulled in the latest version of the hms-test image, executing its Helm CT tests, and verifying that they passed. Also verified that the test pod was no longer stuck in "NotReady" after the tests completed. Lastly, verified the change in the runCT environment and confirmed that it passed its Snyk checks that were previously failing.

Was a fresh Install tested? N
Was an Upgrade tested? Y
Was a Downgrade tested? N

### Risks and Mitigations

Low risk, minor test changes and CVE remediation.