### PR TITLE
Endpoint history

### DIFF
--- a/changelog/v3.0.md
+++ b/changelog/v3.0.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [3.0.1] - 2023-04-19
+
+### Changed
+
+- Changed to use the BSS image 1.24.0 which fixed the filter options on the endpoint-history API.
+
 ## [3.0.0] - 2023-03-20
 
 ### Changed

--- a/charts/v3.0/cray-hms-bss/Chart.yaml
+++ b/charts/v3.0/cray-hms-bss/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: "cray-hms-bss"
-version: 3.0.0
+version: 3.0.1
 description: "Kubernetes resources for cray-hms-bss"
 home: "https://github.com/Cray-HPE/hms-bss-charts"
 sources:

--- a/charts/v3.0/cray-hms-bss/Chart.yaml
+++ b/charts/v3.0/cray-hms-bss/Chart.yaml
@@ -15,6 +15,6 @@ dependencies:
 maintainers:
   - name: Hardware Management
     url: https://github.com/orgs/Cray-HPE/teams/hardware-management
-appVersion: "1.22.0"
+appVersion: "1.24.0"
 annotations:
   artifacthub.io/license: "MIT"

--- a/charts/v3.0/cray-hms-bss/values.yaml
+++ b/charts/v3.0/cray-hms-bss/values.yaml
@@ -11,8 +11,8 @@
 # See https://connect.us.cray.com/jira/browse/CASMCLOUD-661
 
 global:
-  appVersion: 1.22.0
-  testVersion: 1.22.0
+  appVersion: 1.24.0
+  testVersion: 1.24.0
 
 image:
   repository: artifactory.algol60.net/csm-docker/stable/cray-bss

--- a/cray-hms-bss.compatibility.yaml
+++ b/cray-hms-bss.compatibility.yaml
@@ -25,6 +25,7 @@ chartVersionToApplicationVersion:
   "2.1.5": "1.21.0"
   "2.1.6": "1.22.0"
   "3.0.0": "1.22.0"
+  "3.0.1": "1.24.0"
 
 # Test results for combinations of Chart, Application, and CSM versions.  
 chartValidationLog: []


### PR DESCRIPTION
### Summary and Scope

Fixed the name and endpoint type query parameters when searching the endpoint history.

Changed to only make exact matches on the name. Prior to this change the following query would match both these xnames: x1000c0s0b0n1 and x1000c0s0b0n10.
```
curl -k 'https://localhost:8443/apis/bss/boot/v1/endpoint-history?name=x1000'
curl -k 'https://localhost:8443/apis/bss/boot/v1/endpoint-history?name=x1000c0s0b0n1' 
```

After this change the first query will match zero items and send will match one.

These changes also fix the case where there are no matches on the endpoint query parameter. Prior to this change it would not notice that there were no matches, and would make up a match.

### Issues and Related PRs

* Resolves [CASMHMS-5812](https://jira-pro.its.hpecorp.net:8443/browse/CASMHMS-5812)
* Resolves [CASMHMS-5813](https://jira-pro.its.hpecorp.net:8443/browse/CASMHMS-5813)

### Testing

Tested on:

* docker compose with simulator
* vshasta, however vshasta doesn't simulate the hardware so I wasn't able to generate a endpoint history.

Test description:

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)? Y
- Were continuous integration tests run? If not, why? Y
- Was upgrade tested? If not, why? Y
- Was downgrade tested? If not, why? Y


## Risks and Mitigations

low

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable