### PR TITLE
CASMHMS-6012: Update Chart to set SPIRE_TOKEN_URL to override default value

### DIFF
--- a/changelog/v3.1.md
+++ b/changelog/v3.1.md
@@ -1,0 +1,13 @@
+# Changelog for v3.1
+
+All notable changes to this project for v3.1.Z will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+
+## [3.1.0] - 2023-05-11
+
+### Changed
+
+- Changed to set the SPIRE_TOKEN_URL env variable in the chart to the new value, over-riding the default.

--- a/charts/v3.1/cray-hms-bss/.gitignore
+++ b/charts/v3.1/cray-hms-bss/.gitignore
@@ -1,0 +1,2 @@
+# by default we'll ignore any subcharts included, but simply adjust this if need be
+charts/*

--- a/charts/v3.1/cray-hms-bss/Chart.yaml
+++ b/charts/v3.1/cray-hms-bss/Chart.yaml
@@ -1,0 +1,20 @@
+apiVersion: v2
+name: "cray-hms-bss"
+version: 3.1.0
+description: "Kubernetes resources for cray-hms-bss"
+home: "https://github.com/Cray-HPE/hms-bss-charts"
+sources:
+  - "https://github.com/Cray-HPE/hms-bss"
+dependencies:
+  - name: cray-service
+    version: "~10.0"
+    repository: https://artifactory.algol60.net/artifactory/csm-helm-charts
+  - name: cray-etcd-base
+    version: "~1.0"
+    repository: https://artifactory.algol60.net/artifactory/csm-helm-charts
+maintainers:
+  - name: Hardware Management
+    url: https://github.com/orgs/Cray-HPE/teams/hardware-management
+appVersion: "1.24.0"
+annotations:
+  artifacthub.io/license: "MIT"

--- a/charts/v3.1/cray-hms-bss/templates/configmap.yaml
+++ b/charts/v3.1/cray-hms-bss/templates/configmap.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: bss-env-config
+data:
+  addvertisAddress: {{ .Values.addvertisAddress }}

--- a/charts/v3.1/cray-hms-bss/templates/network.yaml
+++ b/charts/v3.1/cray-hms-bss/templates/network.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: "networking.istio.io/v1alpha3"
+kind: "DestinationRule"
+metadata:
+  name: "cray-bss-datastore"
+  labels:
+    app.kubernetes.io/name: cray-datastore
+spec:
+  host: "cray-datastore"
+  trafficPolicy:
+    tls:
+      mode: ISTIO_MUTUAL
+

--- a/charts/v3.1/cray-hms-bss/templates/tests/test-functional.yaml
+++ b/charts/v3.1/cray-hms-bss/templates/tests/test-functional.yaml
@@ -1,0 +1,59 @@
+{{/*
+MIT License
+
+(C) Copyright 2022 Hewlett Packard Enterprise Development LP
+
+Permission is hereby granted, free of charge, to any person obtaining a
+copy of this software and associated documentation files (the "Software"),
+to deal in the Software without restriction, including without limitation
+the rights to use, copy, modify, merge, publish, distribute, sublicense,
+and/or sell copies of the Software, and to permit persons to whom the
+Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included
+in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+OTHER DEALINGS IN THE SOFTWARE.
+*/}}
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: "{{ .Release.Name }}-test-functional"
+  annotations:
+    "helm.sh/hook": test
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+    "helm.sh/hook-weight": "1" #run this after smoke!
+
+  labels:
+    app.kubernetes.io/name: "{{ .Release.Name }}-test-functional"
+
+spec:
+  backoffLimit: 0
+  template:
+    metadata:
+      name: "{{ .Release.Name }}-test-functional"
+      annotations:
+        "proxy.istio.io/config": '{ "holdApplicationUntilProxyStarts": true }'
+      labels:
+        app.kubernetes.io/managed-by:  "{{ include "cray-service.name" . }}"
+        app.kubernetes.io/instance:  "{{ .Release.Name }}-test-functional"
+        helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
+    spec:
+      restartPolicy: Never
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65534
+        runAsGroup: 65534
+      containers:
+        - name: "functional"
+          image: "{{ .Values.tests.image.repository }}:{{ .Values.global.testVersion }}"
+          imagePullPolicy: "{{ .Values.tests.image.pullPolicy }}"
+          command: ["/bin/sh", "-c"]
+          args: ["entrypoint.sh tavern -c /src/libs/tavern_global_config.yaml -p /src/app/api/1-non-disruptive"]

--- a/charts/v3.1/cray-hms-bss/templates/tests/test-smoke.yaml
+++ b/charts/v3.1/cray-hms-bss/templates/tests/test-smoke.yaml
@@ -1,0 +1,59 @@
+{{/*
+MIT License
+
+(C) Copyright 2022 Hewlett Packard Enterprise Development LP
+
+Permission is hereby granted, free of charge, to any person obtaining a
+copy of this software and associated documentation files (the "Software"),
+to deal in the Software without restriction, including without limitation
+the rights to use, copy, modify, merge, publish, distribute, sublicense,
+and/or sell copies of the Software, and to permit persons to whom the
+Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included
+in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+OTHER DEALINGS IN THE SOFTWARE.
+*/}}
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: "{{ .Release.Name }}-test-smoke"
+  annotations:
+    "helm.sh/hook": test
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+    "helm.sh/hook-weight": "-1" #run this first!
+
+  labels:
+    app.kubernetes.io/name: "{{ .Release.Name }}-test-smoke"
+
+spec:
+  backoffLimit: 0
+  template:
+    metadata:
+      name: "{{ .Release.Name }}-test-smoke"
+      annotations:
+        "proxy.istio.io/config": '{ "holdApplicationUntilProxyStarts": true }'
+      labels:
+        app.kubernetes.io/managed-by:  "{{ include "cray-service.name" . }}"
+        app.kubernetes.io/instance:  "{{ .Release.Name }}-test-smoke"
+        helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
+    spec:
+      restartPolicy: Never
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65534
+        runAsGroup: 65534
+      containers:
+        - name: "smoke"
+          image: "{{ .Values.tests.image.repository }}:{{ .Values.global.testVersion }}"
+          imagePullPolicy: "{{ .Values.tests.image.pullPolicy }}"
+          command: ["/bin/sh", "-c"]
+          args: ["entrypoint.sh smoke -f smoke.json -u http://cray-bss"]

--- a/charts/v3.1/cray-hms-bss/templates/virtualservice.yaml
+++ b/charts/v3.1/cray-hms-bss/templates/virtualservice.yaml
@@ -1,0 +1,17 @@
+apiVersion: networking.istio.io/v1alpha3
+kind: VirtualService
+metadata:
+  name: "cray-bss-cloud-init"
+spec:
+  hosts:
+    - "*"
+  gateways:
+    - services-gateway
+  http:
+    - match:
+      - port: 8888
+      route:
+      - destination:
+          host: cray-bss
+          port:
+            number: 80

--- a/charts/v3.1/cray-hms-bss/values.yaml
+++ b/charts/v3.1/cray-hms-bss/values.yaml
@@ -1,0 +1,151 @@
+# Please refer to https://stash.us.cray.com/projects/CLOUD/repos/cray-charts/browse/stable/cray-service/values.yaml?at=refs%2Fheads%2Fmaster
+# for more info on values you can set/override
+# Note that cray-service.containers[*].image and cray-service.initContainers[*].image map values are one of the only structures that
+# differ from the standard kubernetes container spec:
+# image:
+#   repository: ""
+#   tag: "" (default = "latest")
+#   pullPolicy: "" (default = "IfNotPresent")
+
+# TODO: implement a solution to pass that information from Ansible to Helm instead of hardcoding it
+# See https://connect.us.cray.com/jira/browse/CASMCLOUD-661
+
+global:
+  appVersion: 1.24.0
+  testVersion: 1.24.0
+
+image:
+  repository: artifactory.algol60.net/csm-docker/stable/cray-bss
+  pullPolicy: IfNotPresent
+
+tests:
+  image:
+    repository: artifactory.algol60.net/csm-docker/stable/cray-bss-hmth-test
+    pullPolicy: IfNotPresent
+
+ipxe:
+  dnsServerIp: "10.2.255.253"
+  bssIp: "10.2.255.253"
+  networkIp: "10.2.0.0"
+  netmask: "255.255.0.0"
+  dhcpStart: "10.2.0.5"
+  dhcpStop: "10.2.99.252"
+  routers:
+    - "10.100.33.22"
+
+addvertisAddress: ""
+
+cray-etcd-base:
+  nameOverride: "cray-bss"
+  fullnameOverride: "cray-bss"
+  etcd:
+    enabled: true
+    fullnameOverride: "cray-bss-bitnami-etcd"
+    nameOverride: "cray-bss-bitnami-etcd"
+    priorityClassName: "csm-high-priority-service"
+    extraEnvVars:
+      - name: ETCD_HEARTBEAT_INTERVAL
+        value: "4200"
+      - name: ETCD_ELECTION_TIMEOUT
+        value: "21000"
+      - name: ETCD_MAX_SNAPSHOTS
+        value: "5"
+      - name: ETCD_QUOTA_BACKEND_BYTES
+        value: "10737418240"
+      - name: ETCD_SNAPSHOT_COUNT
+        value: "10000"
+      - name: ETCD_SNAPSHOT_HISTORY_LIMIT
+        value: "24"
+    extraVolumes:
+      - configMap:
+          defaultMode: 420
+          name: cray-bss-bitnami-etcd-config
+        name: etcd-config
+
+cray-service:
+  type: "Deployment"
+  nameOverride: "cray-bss"
+  fullnameOverride: "cray-bss"
+  priorityClassName: csm-high-priority-service
+  replicaCount: 3
+  affinity:
+    podAntiAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+      - topologyKey: kubernetes.io/hostname
+        labelSelector:
+          matchExpressions:
+            - key: app.kubernetes.io/name
+              operator: In
+              values:
+              - cray-bss
+  strategy:
+    rollingUpdate:
+      maxUnavailable: 50%
+    type: RollingUpdate
+  etcdWaitContainer: true
+  containers:
+    cray-bss:
+      name: "cray-bss"
+      image:
+        repository: artifactory.algol60.net/csm-docker/stable/cray-bss
+      resources:
+        limits:
+          cpu: 4
+          memory: 4Gi
+        requests:
+          cpu: 500m
+          memory: 256Mi
+      env:
+        - name: HSM_URL
+          value: "http://cray-smd"  # TODO: figure out correct smd communication considering baked-in TLS expectations
+        - name: NFD_URL
+          value: "http://cray-hmnfd"
+        - name: SPIRE_TOKEN_URL
+          value: "https://spire-tokens.spire:54440"
+        # Remove/comment out the DATASTORE_URL definition to have bss use
+        # ETCD.  The etcd operator will provide the bss container
+        # with ETCD_HOST and ETCD_PORT to allow it to determine the
+        # DATASTORE URL.
+        # - name: DATASTORE_URL
+        #   value: "mem:"
+        - name: S3_ENDPOINT
+          valueFrom:
+            secretKeyRef:
+              name: bss-s3-credentials
+              key: http_s3_endpoint
+        - name: S3_BUCKET
+          value: boot-image
+        - name: S3_ACCESS_KEY
+          valueFrom:
+            secretKeyRef:
+              name: bss-s3-credentials
+              key: access_key
+        - name: S3_SECRET_KEY
+          valueFrom:
+            secretKeyRef:
+              name: bss-s3-credentials
+              key: secret_key
+        - name: BSS_ADVERTISE_ADDRESS
+          valueFrom:
+            configMapKeyRef:
+              name: bss-env-config
+              key: addvertisAddress
+      ports:
+        - name: http
+          containerPort: 27778
+      livenessProbe:
+        httpGet:
+          port: 27778
+          path: /boot/v1/service/status
+        initialDelaySeconds: 5
+        periodSeconds: 3
+      readinessProbe:
+        httpGet:
+          port: 27778
+          path: /boot/v1/service/status/all
+        initialDelaySeconds: 20
+        periodSeconds: 60
+  ingress:
+    enabled: true
+    uri: " "
+    prefix: /apis/bss

--- a/cray-hms-bss.compatibility.yaml
+++ b/cray-hms-bss.compatibility.yaml
@@ -26,6 +26,7 @@ chartVersionToApplicationVersion:
   "2.1.6": "1.22.0"
   "3.0.0": "1.22.0"
   "3.0.1": "1.24.0"
+  "3.1.0": "1.24.0"
 
 # Test results for combinations of Chart, Application, and CSM versions.  
 chartValidationLog: []


### PR DESCRIPTION
## Summary and Scope

Set the environment variable SPIRE_TOKEN_URL to "https://spire-tokens.spire:54440".
This is needed to override the default value as the SPIRE endpoint is being changed.

The BSS service implemented this environment variable when the SPIRE join token
processing was implemented, but until now, the default value has been used.

## Issues and Related PRs

## Testing

Tested on:

  * surtur

Test description:

Manually updated helm chart and upgraded to verify the SPIRE_TOKEN_URL env variable was set and that BSS was honoring it.

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)? No
- Were continuous integration tests run? Not yet.
- Was upgrade tested? Ran helm upgrade to verify env variable was set properly
- Was downgrade tested? Ran helm rollback to revert.


## Risks and Mitigations

This change relies on the Spire service change to a new endpoint.


## Pull Request Checklist

- [ x ] Version number(s) incremented, if applicable
- [ x ] Copyrights updated
- [ x ] License file intact
- [ x ] Target branch correct
- [ x ] CHANGELOG.md updated
- [ x ] Testing is appropriate and complete, if applicable