### PR TITLE
CASMTRIAGE-5391 Add disasterRecovery section

### DIFF
--- a/changelog/v3.1.md
+++ b/changelog/v3.1.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [3.1.1] - 2023-05-18
+
+### Changed
+
+- Added disasterRecovery section to chart
+
 ## [3.1.0] - 2023-05-11
 
 ### Changed

--- a/charts/v3.1/cray-hms-bss/Chart.yaml
+++ b/charts/v3.1/cray-hms-bss/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: "cray-hms-bss"
-version: 3.1.0
+version: 3.1.1
 description: "Kubernetes resources for cray-hms-bss"
 home: "https://github.com/Cray-HPE/hms-bss-charts"
 sources:

--- a/charts/v3.1/cray-hms-bss/values.yaml
+++ b/charts/v3.1/cray-hms-bss/values.yaml
@@ -43,6 +43,12 @@ cray-etcd-base:
     fullnameOverride: "cray-bss-bitnami-etcd"
     nameOverride: "cray-bss-bitnami-etcd"
     priorityClassName: "csm-high-priority-service"
+    disasterRecovery:
+      cronjob:
+        snapshotsDir: "/snapshots/cray-bss-bitnami-etcd"
+        schedule: "0 */1 * * *"
+        historyLimit: 1
+        snapshotHistoryLimit: 24
     extraEnvVars:
       - name: ETCD_HEARTBEAT_INTERVAL
         value: "4200"

--- a/cray-hms-bss.compatibility.yaml
+++ b/cray-hms-bss.compatibility.yaml
@@ -27,6 +27,7 @@ chartVersionToApplicationVersion:
   "3.0.0": "1.22.0"
   "3.0.1": "1.24.0"
   "3.1.0": "1.24.0"
+  "3.1.1": "1.24.0"
 
 # Test results for combinations of Chart, Application, and CSM versions.  
 chartValidationLog: []


### PR DESCRIPTION
## Summary and Scope

Add required disasterRecovery chart section to allow for ETCD backups.

## Issues and Related PRs

* Resolves [CASMTRIAGE-5391](https://jira-pro.its.hpecorp.net:8443/browse/CASMTRIAGE-5391)

## Testing

Tested on:

  * `drax`

Test description:

Copied chart to drax and initiated a helm upgrade. Verified deployed chart contained the expected changes.

## Risks and Mitigations

No known risks.

## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable