### PR TITLE
CASMHMS-6018 dmsquash-live pre-signed URL

### DIFF
--- a/changelog/v3.1.md
+++ b/changelog/v3.1.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [3.1.2] - 2023-05-23
+
+- CASMHMS-6018 Added pre-signed URL support for dmsquash-live (`root=live:s3://<url>`)
+
 ## [3.1.1] - 2023-05-18
 
 ### Changed

--- a/charts/v3.1/cray-hms-bss/Chart.yaml
+++ b/charts/v3.1/cray-hms-bss/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: "cray-hms-bss"
-version: 3.1.1
+version: 3.1.2
 description: "Kubernetes resources for cray-hms-bss"
 home: "https://github.com/Cray-HPE/hms-bss-charts"
 sources:
@@ -15,6 +15,6 @@ dependencies:
 maintainers:
   - name: Hardware Management
     url: https://github.com/orgs/Cray-HPE/teams/hardware-management
-appVersion: "1.24.0"
+appVersion: "1.25.0"
 annotations:
   artifacthub.io/license: "MIT"

--- a/charts/v3.1/cray-hms-bss/values.yaml
+++ b/charts/v3.1/cray-hms-bss/values.yaml
@@ -11,8 +11,8 @@
 # See https://connect.us.cray.com/jira/browse/CASMCLOUD-661
 
 global:
-  appVersion: 1.24.0
-  testVersion: 1.24.0
+  appVersion: 1.25.0
+  testVersion: 1.25.0
 
 image:
   repository: artifactory.algol60.net/csm-docker/stable/cray-bss

--- a/cray-hms-bss.compatibility.yaml
+++ b/cray-hms-bss.compatibility.yaml
@@ -6,7 +6,7 @@ chartVersionToCSMVersion:
   ">=2.1.0": "~1.3.0"
   ">=3.0.0": "~1.4.0"
 
-# The application version must be compliant to semantic versioning. 
+# The application version must be compliant to semantic versioning.
 # If the application makes a backwards incompatible change, then its major version needs to be increment.
 # This is the idealized world
 chartVersionToApplicationVersion:
@@ -28,13 +28,14 @@ chartVersionToApplicationVersion:
   "3.0.1": "1.24.0"
   "3.1.0": "1.24.0"
   "3.1.1": "1.24.0"
+  "3.1.2": "1.25.0"
 
-# Test results for combinations of Chart, Application, and CSM versions.  
+# Test results for combinations of Chart, Application, and CSM versions.
 chartValidationLog: []
 # - chartVersion: 2.0.0
 #   applicationVersion: 1.11.0
 #   csm: 1.2.0-alpha.16
-#   environment: baremetal 
-#   result: PASS 
+#   environment: baremetal
+#   result: PASS
 #   tester: rsjostrand-hpe
 #   date: 2021-11-17


### PR DESCRIPTION
## Summary and Scope

_Summarize what has changed. Explain why this PR is necessary. What is impacted? Is this a new feature, critical bug fix, etc?_

Add pre-signed URL support for the `dmsquash-live` dracut module (`root=live:<url>`).

_Is this change backwards incompatible, backwards compatible, or a backwards compatible bugfix?_

Yes.

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves [CASMHMS-6018](https://jira-pro.it.hpe.com:8443/browse/CASMHMS-6018)

## Testing

_List the environments in which these changes were tested._

Tested on:

  * `mug`

Test description:

The new image was loaded and resulted in a successful boot when using the native dracut live image `root=live:s3://<url>` parameter.

## Risks and Mitigations

_Are there known issues with these changes? Any other special considerations?_


## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [ ] Target branch correct
- [ ] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable