### PR TITLE
CASMHMS-6047 New environmental variable for ETCD cluster

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) [2021-2022] Cray / HPE
+Copyright (c) [2021-2023] Cray / HPE
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/changelog/v3.1.md
+++ b/changelog/v3.1.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [3.1.3] - 2023-06-23
+
+### Added
+
+- New environmental variable for ETCD cluster
+
 ## [3.1.2] - 2023-05-23
 
 - CASMHMS-6018 Added pre-signed URL support for dmsquash-live (`root=live:s3://<url>`)

--- a/charts/v3.1/cray-hms-bss/Chart.yaml
+++ b/charts/v3.1/cray-hms-bss/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: "cray-hms-bss"
-version: 3.1.2
+version: 3.1.3
 description: "Kubernetes resources for cray-hms-bss"
 home: "https://github.com/Cray-HPE/hms-bss-charts"
 sources:

--- a/charts/v3.1/cray-hms-bss/values.yaml
+++ b/charts/v3.1/cray-hms-bss/values.yaml
@@ -62,6 +62,8 @@ cray-etcd-base:
         value: "10000"
       - name: ETCD_SNAPSHOT_HISTORY_LIMIT
         value: "24"
+      - name: ETCD_DISABLE_PRESTOP
+        value: "yes"
     extraVolumes:
       - configMap:
           defaultMode: 420

--- a/cray-hms-bss.compatibility.yaml
+++ b/cray-hms-bss.compatibility.yaml
@@ -29,6 +29,7 @@ chartVersionToApplicationVersion:
   "3.1.0": "1.24.0"
   "3.1.1": "1.24.0"
   "3.1.2": "1.25.0"
+  "3.1.3": "1.25.0"
 
 # Test results for combinations of Chart, Application, and CSM versions.
 chartValidationLog: []


### PR DESCRIPTION
## Summary and Scope

Update to ETCD portion of chart due to release critical issue in the old ETCD chart.

## Issues and Related PRs

* Resolves [CASMHMS-6047](https://jira-pro.it.hpe.com:8443/browse/CASMHMS-6047)

## Testing

Tested on:

  * `ashton`

Test description:

Validate I can deploy the new chart and the proper version of ETCD was included.

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)? N
- Were continuous integration tests run? If not, why? Y
- Was upgrade tested? If not, why? Y
- Was downgrade tested? If not, why? Y

## Risks and Mitigations

No known risks

## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable