### PR TITLE
CASMHMS-5970 Add retry when getting a bootscript

### DIFF
--- a/changelog/v3.1.md
+++ b/changelog/v3.1.md
@@ -5,6 +5,11 @@ All notable changes to this project for v3.1.Z will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.1.4] - 2023-07-10
+
+### Added
+
+- Retries to destructive bootscript CT test
 
 ## [3.1.3] - 2023-06-23
 

--- a/charts/v3.1/cray-hms-bss/Chart.yaml
+++ b/charts/v3.1/cray-hms-bss/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: "cray-hms-bss"
-version: 3.1.3
+version: 3.1.4
 description: "Kubernetes resources for cray-hms-bss"
 home: "https://github.com/Cray-HPE/hms-bss-charts"
 sources:
@@ -15,6 +15,6 @@ dependencies:
 maintainers:
   - name: Hardware Management
     url: https://github.com/orgs/Cray-HPE/teams/hardware-management
-appVersion: "1.25.0"
+appVersion: "1.26.0"
 annotations:
   artifacthub.io/license: "MIT"

--- a/charts/v3.1/cray-hms-bss/values.yaml
+++ b/charts/v3.1/cray-hms-bss/values.yaml
@@ -11,8 +11,8 @@
 # See https://connect.us.cray.com/jira/browse/CASMCLOUD-661
 
 global:
-  appVersion: 1.25.0
-  testVersion: 1.25.0
+  appVersion: 1.26.0
+  testVersion: 1.26.0
 
 image:
   repository: artifactory.algol60.net/csm-docker/stable/cray-bss

--- a/cray-hms-bss.compatibility.yaml
+++ b/cray-hms-bss.compatibility.yaml
@@ -30,6 +30,7 @@ chartVersionToApplicationVersion:
   "3.1.1": "1.24.0"
   "3.1.2": "1.25.0"
   "3.1.3": "1.25.0"
+  "3.1.4": "1.26.0"
 
 # Test results for combinations of Chart, Application, and CSM versions.
 chartValidationLog: []


### PR DESCRIPTION
### Summary and Scope

This PR adds retries to the destructive bootscript CT test cases. Sometimes BSS returns a bootscript to re-attempt getting a bootscript, and this normally happens when BSS is syncing with HSM. Add retries to account for this.

### Issues and Related PRs

* Resolves [CASMHMS-5970](https://jira-pro.it.hpe.com:8443/browse/CASMHMS-5970).

### Testing

Was a fresh Install tested? N
Was an Upgrade tested? N
Was a Downgrade tested? N

### Risks and Mitigations

Low risk, fixes an issue that only seems to occur in the hms-nightly-integration test runs.