### PR TITLE
Changed to Call `imgstat` after an initrd is downloaded

### DIFF
--- a/changelog/v3.2.md
+++ b/changelog/v3.2.md
@@ -5,6 +5,12 @@ All notable changes to this project for v3.2.Z will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.2.3] - 2024-09-30
+
+### Changed
+
+- Call `imgstat` after an initrd is downloaded to print out its filesize.
+
 ## [3.2.2] - 2024-08-30
 
 ### Changed

--- a/charts/v3.2/cray-hms-bss/Chart.yaml
+++ b/charts/v3.2/cray-hms-bss/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: "cray-hms-bss"
-version: 3.2.2
+version: 3.2.3
 description: "Kubernetes resources for cray-hms-bss"
 home: "https://github.com/Cray-HPE/hms-bss-charts"
 sources:
@@ -15,6 +15,6 @@ dependencies:
 maintainers:
   - name: Hardware Management
     url: https://github.com/orgs/Cray-HPE/teams/hardware-management
-appVersion: "1.26.0"
+appVersion: "1.27.0"
 annotations:
   artifacthub.io/license: "MIT"

--- a/charts/v3.2/cray-hms-bss/values.yaml
+++ b/charts/v3.2/cray-hms-bss/values.yaml
@@ -11,8 +11,8 @@
 # See https://connect.us.cray.com/jira/browse/CASMCLOUD-661
 
 global:
-  appVersion: 1.26.0
-  testVersion: 1.26.0
+  appVersion: 1.27.0
+  testVersion: 1.27.0
 
 image:
   repository: artifactory.algol60.net/csm-docker/stable/cray-bss

--- a/cray-hms-bss.compatibility.yaml
+++ b/cray-hms-bss.compatibility.yaml
@@ -44,6 +44,7 @@ chartVersionToApplicationVersion:
   "3.2.0": "1.26.0"
   "3.2.1": "1.26.0"
   "3.2.2": "1.26.0"
+  "3.2.3": "1.27.0"
 
 # Test results for combinations of Chart, Application, and CSM versions.
 chartValidationLog: []


### PR DESCRIPTION
## Summary and Scope

- Updated app version to 1.27.0
- App changed to call `imgstat` after an initrd is downloaded to print out its filesize.

CASMHMS-6281

## Issues and Related PRs

* Resolves [CASMHMS-6281](https://jira-pro.it.hpe.com:8443/browse/CASMHMS-6281)

## Testing


## Risks and Mitigations

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable