### PR TITLE
CASMHMS-6324: Added support for ppprof builds

### DIFF
--- a/changelog/v3.2.md
+++ b/changelog/v3.2.md
@@ -5,6 +5,12 @@ All notable changes to this project for v3.2.Z will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.2.6] - 2025-01-08
+
+### Added
+
+- Added support for ppprof builds
+
 ## [3.2.5] - 2024-11-18
 
 ### Changed

--- a/charts/v3.2/cray-hms-bss/Chart.yaml
+++ b/charts/v3.2/cray-hms-bss/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: "cray-hms-bss"
-version: 3.2.5
+version: 3.2.6
 description: "Kubernetes resources for cray-hms-bss"
 home: "https://github.com/Cray-HPE/hms-bss-charts"
 sources:
@@ -15,6 +15,6 @@ dependencies:
 maintainers:
   - name: Hardware Management
     url: https://github.com/orgs/Cray-HPE/teams/hardware-management
-appVersion: "1.29.0"
+appVersion: "1.30.0"
 annotations:
   artifacthub.io/license: "MIT"

--- a/charts/v3.2/cray-hms-bss/Chart.yaml
+++ b/charts/v3.2/cray-hms-bss/Chart.yaml
@@ -15,6 +15,9 @@ dependencies:
 maintainers:
   - name: Hardware Management
     url: https://github.com/orgs/Cray-HPE/teams/hardware-management
-appVersion: "1.30.0"
+appVersion: "1.30.0"  # update pprof image version below as well
 annotations:
+  artifacthub.io/images: |-
+    - name: cray-bss-pprof
+      image: artifactory.algol60.net/csm-docker/stable/cray-bss-pprof:1.30.0
   artifacthub.io/license: "MIT"

--- a/charts/v3.2/cray-hms-bss/values.yaml
+++ b/charts/v3.2/cray-hms-bss/values.yaml
@@ -11,8 +11,8 @@
 # See https://connect.us.cray.com/jira/browse/CASMCLOUD-661
 
 global:
-  appVersion: 1.29.0
-  testVersion: 1.29.0
+  appVersion: 1.30.0
+  testVersion: 1.30.0
 
 image:
   repository: artifactory.algol60.net/csm-docker/stable/cray-bss

--- a/cray-hms-bss.compatibility.yaml
+++ b/cray-hms-bss.compatibility.yaml
@@ -47,6 +47,7 @@ chartVersionToApplicationVersion:
   "3.2.3": "1.27.0"
   "3.2.4": "1.28.0"
   "3.2.5": "1.29.0"
+  "3.2.6": "1.30.0"
 
 # Test results for combinations of Chart, Application, and CSM versions.
 chartValidationLog: []


### PR DESCRIPTION
## Summary and Scope

Added support for building a pprof enabled image.  Profiling adds runtime overhead so the pprof enabled image is not used by default.  It is meant to be a debug tool.  In order to use the enabled pprof image, edit the deployment and append "-pprof" to the image name.  For unstable developer builds, be sure to change the built timestamp as well.

Adopted app version 1.30.0 for CSM 1.6.1 (helm chart 3.2.6)

## Issues and Related PRs

* Resolves [CASMHMS-6324](https://jira-pro.it.hpe.com:8443/browse/CASMHMS-6324)

## Testing

Tested on:

  * `mug`

Test description:

- Deployed service with pprof enabled - confirmed pprof functionality
- Deployed services with pprof disabled - confirmed pprof support not built into binary
- Functional tests (if they exist) was successfully ran with and without pprof enabled

Test Checklist:

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)? Y
- Were continuous integration tests run? If not, why? Y
- Was upgrade tested? If not, why? Y
- Was downgrade tested? If not, why? Y

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable