### PR TITLE
CASMHMS-5678: Update image and module dependencies

### DIFF
--- a/changelog/v3.3.md
+++ b/changelog/v3.3.md
@@ -1,0 +1,13 @@
+# Changelog for v3.3
+
+All notable changes to this project for v3.3.Z will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [3.3.0] - 2025-02-07
+
+### Security
+
+- Update image and module dependencies
+- Various code changes to accommodate module updates

--- a/changelog/v3.3.md
+++ b/changelog/v3.3.md
@@ -5,7 +5,7 @@ All notable changes to this project for v3.3.Z will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [3.3.0] - 2025-02-07
+## [3.3.0] - 2025-01-29
 
 ### Security
 

--- a/charts/v3.3/cray-hms-bss/.gitignore
+++ b/charts/v3.3/cray-hms-bss/.gitignore
@@ -1,0 +1,2 @@
+# by default we'll ignore any subcharts included, but simply adjust this if need be
+charts/*

--- a/charts/v3.3/cray-hms-bss/Chart.yaml
+++ b/charts/v3.3/cray-hms-bss/Chart.yaml
@@ -1,0 +1,23 @@
+apiVersion: v2
+name: "cray-hms-bss"
+version: 3.3.0
+description: "Kubernetes resources for cray-hms-bss"
+home: "https://github.com/Cray-HPE/hms-bss-charts"
+sources:
+  - "https://github.com/Cray-HPE/hms-bss"
+dependencies:
+  - name: cray-service
+    version: "~11.0"
+    repository: https://artifactory.algol60.net/artifactory/csm-helm-charts
+  - name: cray-etcd-base
+    version: "~1.2"
+    repository: https://artifactory.algol60.net/artifactory/csm-helm-charts
+maintainers:
+  - name: Hardware Management
+    url: https://github.com/orgs/Cray-HPE/teams/hardware-management
+appVersion: "1.31.0"  # update pprof image version below as well
+annotations:
+  artifacthub.io/images: |-
+    - name: cray-bss-pprof
+      image: artifactory.algol60.net/csm-docker/stable/cray-bss-pprof:1.31.0
+  artifacthub.io/license: "MIT"

--- a/charts/v3.3/cray-hms-bss/templates/configmap.yaml
+++ b/charts/v3.3/cray-hms-bss/templates/configmap.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: bss-env-config
+data:
+  addvertisAddress: {{ .Values.addvertisAddress }}

--- a/charts/v3.3/cray-hms-bss/templates/network.yaml
+++ b/charts/v3.3/cray-hms-bss/templates/network.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: "networking.istio.io/v1alpha3"
+kind: "DestinationRule"
+metadata:
+  name: "cray-bss-datastore"
+  labels:
+    app.kubernetes.io/name: cray-datastore
+spec:
+  host: "cray-datastore"
+  trafficPolicy:
+    tls:
+      mode: ISTIO_MUTUAL
+

--- a/charts/v3.3/cray-hms-bss/templates/tests/test-functional.yaml
+++ b/charts/v3.3/cray-hms-bss/templates/tests/test-functional.yaml
@@ -1,0 +1,59 @@
+{{/*
+MIT License
+
+(C) Copyright 2022 Hewlett Packard Enterprise Development LP
+
+Permission is hereby granted, free of charge, to any person obtaining a
+copy of this software and associated documentation files (the "Software"),
+to deal in the Software without restriction, including without limitation
+the rights to use, copy, modify, merge, publish, distribute, sublicense,
+and/or sell copies of the Software, and to permit persons to whom the
+Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included
+in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+OTHER DEALINGS IN THE SOFTWARE.
+*/}}
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: "{{ .Release.Name }}-test-functional"
+  annotations:
+    "helm.sh/hook": test
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+    "helm.sh/hook-weight": "1" #run this after smoke!
+
+  labels:
+    app.kubernetes.io/name: "{{ .Release.Name }}-test-functional"
+
+spec:
+  backoffLimit: 0
+  template:
+    metadata:
+      name: "{{ .Release.Name }}-test-functional"
+      annotations:
+        "proxy.istio.io/config": '{ "holdApplicationUntilProxyStarts": true }'
+      labels:
+        app.kubernetes.io/managed-by:  "{{ include "cray-service.name" . }}"
+        app.kubernetes.io/instance:  "{{ .Release.Name }}-test-functional"
+        helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
+    spec:
+      restartPolicy: Never
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65534
+        runAsGroup: 65534
+      containers:
+        - name: "functional"
+          image: "{{ .Values.tests.image.repository }}:{{ .Values.global.testVersion }}"
+          imagePullPolicy: "{{ .Values.tests.image.pullPolicy }}"
+          command: ["/bin/sh", "-c"]
+          args: ["entrypoint.sh tavern -c /src/libs/tavern_global_config.yaml -p /src/app/api/1-non-disruptive"]

--- a/charts/v3.3/cray-hms-bss/templates/tests/test-smoke.yaml
+++ b/charts/v3.3/cray-hms-bss/templates/tests/test-smoke.yaml
@@ -1,0 +1,59 @@
+{{/*
+MIT License
+
+(C) Copyright 2022 Hewlett Packard Enterprise Development LP
+
+Permission is hereby granted, free of charge, to any person obtaining a
+copy of this software and associated documentation files (the "Software"),
+to deal in the Software without restriction, including without limitation
+the rights to use, copy, modify, merge, publish, distribute, sublicense,
+and/or sell copies of the Software, and to permit persons to whom the
+Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included
+in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+OTHER DEALINGS IN THE SOFTWARE.
+*/}}
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: "{{ .Release.Name }}-test-smoke"
+  annotations:
+    "helm.sh/hook": test
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+    "helm.sh/hook-weight": "-1" #run this first!
+
+  labels:
+    app.kubernetes.io/name: "{{ .Release.Name }}-test-smoke"
+
+spec:
+  backoffLimit: 0
+  template:
+    metadata:
+      name: "{{ .Release.Name }}-test-smoke"
+      annotations:
+        "proxy.istio.io/config": '{ "holdApplicationUntilProxyStarts": true }'
+      labels:
+        app.kubernetes.io/managed-by:  "{{ include "cray-service.name" . }}"
+        app.kubernetes.io/instance:  "{{ .Release.Name }}-test-smoke"
+        helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
+    spec:
+      restartPolicy: Never
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65534
+        runAsGroup: 65534
+      containers:
+        - name: "smoke"
+          image: "{{ .Values.tests.image.repository }}:{{ .Values.global.testVersion }}"
+          imagePullPolicy: "{{ .Values.tests.image.pullPolicy }}"
+          command: ["/bin/sh", "-c"]
+          args: ["entrypoint.sh smoke -f smoke.json -u http://cray-bss"]

--- a/charts/v3.3/cray-hms-bss/templates/virtualservice.yaml
+++ b/charts/v3.3/cray-hms-bss/templates/virtualservice.yaml
@@ -1,0 +1,17 @@
+apiVersion: networking.istio.io/v1alpha3
+kind: VirtualService
+metadata:
+  name: "cray-bss-cloud-init"
+spec:
+  hosts:
+    - "*"
+  gateways:
+    - services-gateway
+  http:
+    - match:
+      - port: 8888
+      route:
+      - destination:
+          host: cray-bss
+          port:
+            number: 80

--- a/charts/v3.3/cray-hms-bss/values.yaml
+++ b/charts/v3.3/cray-hms-bss/values.yaml
@@ -1,0 +1,159 @@
+# Please refer to https://stash.us.cray.com/projects/CLOUD/repos/cray-charts/browse/stable/cray-service/values.yaml?at=refs%2Fheads%2Fmaster
+# for more info on values you can set/override
+# Note that cray-service.containers[*].image and cray-service.initContainers[*].image map values are one of the only structures that
+# differ from the standard kubernetes container spec:
+# image:
+#   repository: ""
+#   tag: "" (default = "latest")
+#   pullPolicy: "" (default = "IfNotPresent")
+
+# TODO: implement a solution to pass that information from Ansible to Helm instead of hardcoding it
+# See https://connect.us.cray.com/jira/browse/CASMCLOUD-661
+
+global:
+  appVersion: 1.31.0
+  testVersion: 1.31.0
+
+image:
+  repository: artifactory.algol60.net/csm-docker/stable/cray-bss
+  pullPolicy: IfNotPresent
+
+tests:
+  image:
+    repository: artifactory.algol60.net/csm-docker/stable/cray-bss-hmth-test
+    pullPolicy: IfNotPresent
+
+ipxe:
+  dnsServerIp: "10.2.255.253"
+  bssIp: "10.2.255.253"
+  networkIp: "10.2.0.0"
+  netmask: "255.255.0.0"
+  dhcpStart: "10.2.0.5"
+  dhcpStop: "10.2.99.252"
+  routers:
+    - "10.100.33.22"
+
+addvertisAddress: ""
+
+cray-etcd-base:
+  nameOverride: "cray-bss"
+  fullnameOverride: "cray-bss"
+  etcd:
+    enabled: true
+    fullnameOverride: "cray-bss-bitnami-etcd"
+    nameOverride: "cray-bss-bitnami-etcd"
+    priorityClassName: "csm-high-priority-service"
+    disasterRecovery:
+      cronjob:
+        snapshotsDir: "/snapshots/cray-bss-bitnami-etcd"
+        schedule: "0 */1 * * *"
+        historyLimit: 1
+        snapshotHistoryLimit: 24
+    extraEnvVars:
+      - name: ETCD_HEARTBEAT_INTERVAL
+        value: "4200"
+      - name: ETCD_ELECTION_TIMEOUT
+        value: "21000"
+      - name: ETCD_MAX_SNAPSHOTS
+        value: "5"
+      - name: ETCD_QUOTA_BACKEND_BYTES
+        value: "10737418240"
+      - name: ETCD_SNAPSHOT_COUNT
+        value: "10000"
+      - name: ETCD_SNAPSHOT_HISTORY_LIMIT
+        value: "24"
+      - name: ETCD_DISABLE_PRESTOP
+        value: "yes"
+    extraVolumes:
+      - configMap:
+          defaultMode: 420
+          name: cray-bss-bitnami-etcd-config
+        name: etcd-config
+
+cray-service:
+  type: "Deployment"
+  nameOverride: "cray-bss"
+  fullnameOverride: "cray-bss"
+  priorityClassName: csm-high-priority-service
+  replicaCount: 3
+  affinity:
+    podAntiAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+      - topologyKey: kubernetes.io/hostname
+        labelSelector:
+          matchExpressions:
+            - key: app.kubernetes.io/name
+              operator: In
+              values:
+              - cray-bss
+  strategy:
+    rollingUpdate:
+      maxUnavailable: 50%
+    type: RollingUpdate
+  etcdWaitContainer: true
+  containers:
+    cray-bss:
+      name: "cray-bss"
+      image:
+        repository: artifactory.algol60.net/csm-docker/stable/cray-bss
+      resources:
+        limits:
+          cpu: 4
+          memory: 4Gi
+        requests:
+          cpu: 500m
+          memory: 256Mi
+      env:
+        - name: HSM_URL
+          value: "http://cray-smd"  # TODO: figure out correct smd communication considering baked-in TLS expectations
+        - name: NFD_URL
+          value: "http://cray-hmnfd"
+        - name: SPIRE_TOKEN_URL
+          value: "https://spire-tokens.spire:54440"
+        # Remove/comment out the DATASTORE_URL definition to have bss use
+        # ETCD.  The etcd operator will provide the bss container
+        # with ETCD_HOST and ETCD_PORT to allow it to determine the
+        # DATASTORE URL.
+        # - name: DATASTORE_URL
+        #   value: "mem:"
+        - name: S3_ENDPOINT
+          valueFrom:
+            secretKeyRef:
+              name: bss-s3-credentials
+              key: http_s3_endpoint
+        - name: S3_BUCKET
+          value: boot-image
+        - name: S3_ACCESS_KEY
+          valueFrom:
+            secretKeyRef:
+              name: bss-s3-credentials
+              key: access_key
+        - name: S3_SECRET_KEY
+          valueFrom:
+            secretKeyRef:
+              name: bss-s3-credentials
+              key: secret_key
+        - name: BSS_ADVERTISE_ADDRESS
+          valueFrom:
+            configMapKeyRef:
+              name: bss-env-config
+              key: addvertisAddress
+      ports:
+        - name: http
+          containerPort: 27778
+      livenessProbe:
+        httpGet:
+          port: 27778
+          path: /boot/v1/service/status
+        initialDelaySeconds: 5
+        periodSeconds: 3
+      readinessProbe:
+        httpGet:
+          port: 27778
+          path: /boot/v1/service/status/all
+        initialDelaySeconds: 20
+        periodSeconds: 60
+  ingress:
+    enabled: true
+    uri: " "
+    prefix: /apis/bss

--- a/cray-hms-bss.compatibility.yaml
+++ b/cray-hms-bss.compatibility.yaml
@@ -6,7 +6,8 @@ chartVersionToCSMVersion:
   #   Chart Version: 2.1.0 <= x.y.z < 3.0.0, CSM Version: 1.3.0 <= x.y.z < 1.4.0
   #   Chart Version: 3.0.0 <= x.y.z < 3.1.0, CSM Version: 1.4.0 <= x.y.z < 1.5.0
   #   Chart Version: 3.1.0 <= x.y.z < 3.2.0, CSM Version: 1.5.0 <= x.y.z < 1.6.0
-  #   Chart Version: 3.2.0 <= x.y.z,         CSM Version: 1.6.0 <= x.y.z
+  #   Chart Version: 3.2.0 <= x.y.z < 3.3.0, CSM Version: 1.6.0 <= x.y.z < 1.7.0
+  #   Chart Version: 3.3.0 <= x.y.z,         CSM Version: 1.7.0 <= x.y.z
   #
   # Chart version: CSM version
   ">=2.0.0": "~1.2.0"
@@ -14,6 +15,7 @@ chartVersionToCSMVersion:
   ">=3.0.0": "~1.4.0"
   ">=3.1.0": "~1.5.0"
   ">=3.2.0": "~1.6.0" # 3.2 is csm 1.6 only because of cray-etcd-base 1.1 or later
+  ">=3.3.0": "~1.7.0"
 
 # The application version must be compliant to semantic versioning.
 # If the application makes a backwards incompatible change, then its major version needs to be increment.
@@ -48,6 +50,7 @@ chartVersionToApplicationVersion:
   "3.2.4": "1.28.0"
   "3.2.5": "1.29.0"
   "3.2.6": "1.30.0"
+  "3.3.0": "1.31.0"
 
 # Test results for combinations of Chart, Application, and CSM versions.
 chartValidationLog: []


### PR DESCRIPTION
### Summary and Scope

Updated image and module dependencies for security updates.

Fixed a few pre-existing build warnings in Dockerfiles and docker compose files as it was difficult to look for possible new warnings/errors associated with the image and module updates.

Removed deprecated Version from docker compose files

Adopted app version 1.31.0 for CSM 1.7.0 (helm chart 3.3.0)

### Issues and Related PRs

* Resolves [CASMHMS-5678](https://jira-pro.it.hpe.com:8443/browse/CASMHMS-5678)

### Testing

Ran smoke and integration tests on `mug`.  Watched log files for any unusual issues.

Tested on:

* `mug`

Were the install/upgrade based validation checks/tests run?(goss tests/install-validation doc) Y
Were continuous integration tests run? Y/N   If not, Why? Y
Was an Upgrade tested?                 Y/N   If not, Why? Y 
Was a Downgrade tested?                Y/N   If not, Why? Y 

### Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable

### High Level Diff of Changes
```
> diff -r charts/v3.2/ charts/v3.3/
diff -r charts/v3.2/cray-hms-bss/Chart.yaml charts/v3.3/cray-hms-bss/Chart.yaml
3c3
< version: 3.2.6
---
> version: 3.3.0
18c18
< appVersion: "1.30.0"  # update pprof image version below as well
---
> appVersion: "1.31.0"  # update pprof image version below as well
22c22
<       image: artifactory.algol60.net/csm-docker/stable/cray-bss-pprof:1.30.0
---
>       image: artifactory.algol60.net/csm-docker/stable/cray-bss-pprof:1.31.0
diff -r charts/v3.2/cray-hms-bss/values.yaml charts/v3.3/cray-hms-bss/values.yaml
14,15c14,15
<   appVersion: 1.30.0
<   testVersion: 1.30.0
---
>   appVersion: 1.31.0
>   testVersion: 1.31.0
```