### PR TITLE
CASMHMS-6372: Revert back from v3 to v2 of gopkg.in/yaml due to upstream bugs

### DIFF
--- a/changelog/v3.3.md
+++ b/changelog/v3.3.md
@@ -5,6 +5,12 @@ All notable changes to this project for v3.3.Z will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.3.1] - 2025-02-05
+
+### Changed
+
+- Revert back from v3 to v2 of gopkg.in/yaml due to upstream bugs
+
 ## [3.3.0] - 2025-01-29
 
 ### Security

--- a/charts/v3.3/cray-hms-bss/Chart.yaml
+++ b/charts/v3.3/cray-hms-bss/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: "cray-hms-bss"
-version: 3.3.0
+version: 3.3.1
 description: "Kubernetes resources for cray-hms-bss"
 home: "https://github.com/Cray-HPE/hms-bss-charts"
 sources:
@@ -15,9 +15,9 @@ dependencies:
 maintainers:
   - name: Hardware Management
     url: https://github.com/orgs/Cray-HPE/teams/hardware-management
-appVersion: "1.31.0"  # update pprof image version below as well
+appVersion: "1.32.0"  # update pprof image version below as well
 annotations:
   artifacthub.io/images: |-
     - name: cray-bss-pprof
-      image: artifactory.algol60.net/csm-docker/stable/cray-bss-pprof:1.31.0
+      image: artifactory.algol60.net/csm-docker/stable/cray-bss-pprof:1.32.0
   artifacthub.io/license: "MIT"

--- a/charts/v3.3/cray-hms-bss/values.yaml
+++ b/charts/v3.3/cray-hms-bss/values.yaml
@@ -11,8 +11,8 @@
 # See https://connect.us.cray.com/jira/browse/CASMCLOUD-661
 
 global:
-  appVersion: 1.31.0
-  testVersion: 1.31.0
+  appVersion: 1.32.0
+  testVersion: 1.32.0
 
 image:
   repository: artifactory.algol60.net/csm-docker/stable/cray-bss

--- a/cray-hms-bss.compatibility.yaml
+++ b/cray-hms-bss.compatibility.yaml
@@ -51,6 +51,7 @@ chartVersionToApplicationVersion:
   "3.2.5": "1.29.0"
   "3.2.6": "1.30.0"
   "3.3.0": "1.31.0"
+  "3.3.1": "1.32.0"
 
 # Test results for combinations of Chart, Application, and CSM versions.
 chartValidationLog: []


### PR DESCRIPTION
### Summary and Scope

Revert back from v3 to v2 of gopkg.in/yaml due to upstream bugs in v3 that caused issues in vshasta upgrade.

Adopted app version 1.32.0 for CSM 1.7.0 (helm chart 3.3.1)

### Issues and Related PRs

* Resolves [CASMHMS-6372](https://jira-pro.it.hpe.com:8443/browse/CASMHMS-6372)

### Testing

Ran smoke and integration tests on `mug`.  Watched log files for any unusual issues.

Tested on:

* `mug`

Were the install/upgrade based validation checks/tests run?(goss tests/install-validation doc) Y
Were continuous integration tests run? Y/N   If not, Why? Y
Was an Upgrade tested?                 Y/N   If not, Why? Y 
Was a Downgrade tested?                Y/N   If not, Why? Y 

### Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable