### PR TITLE
CASMHMS-6389: Explicitly closed all request and response bodies

### DIFF
--- a/changelog/v3.3.md
+++ b/changelog/v3.3.md
@@ -5,6 +5,16 @@ All notable changes to this project for v3.3.Z will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.3.4] - 2025-05-27
+
+### Updated
+
+- Updated image and module dependencies
+- Updated Go vo v1.24
+- Explicitly closed all request and response bodies using hms-base functions
+- Fixed bug with jq use in runSnyk.sh
+- Internal tracking ticket: CASMHMS-6389
+
 ## [3.3.3] - 2025-05-14
 
 ### Updated

--- a/changelog/v3.3.md
+++ b/changelog/v3.3.md
@@ -5,7 +5,7 @@ All notable changes to this project for v3.3.Z will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [3.3.4] - 2025-05-27
+## [3.3.4] - 2025-05-28
 
 ### Updated
 

--- a/charts/v3.3/cray-hms-bss/Chart.yaml
+++ b/charts/v3.3/cray-hms-bss/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: "cray-hms-bss"
-version: 3.3.3
+version: 3.3.4
 description: "Kubernetes resources for cray-hms-bss"
 home: "https://github.com/Cray-HPE/hms-bss-charts"
 sources:
@@ -15,9 +15,9 @@ dependencies:
 maintainers:
   - name: Hardware Management
     url: https://github.com/orgs/Cray-HPE/teams/hardware-management
-appVersion: "1.33.0"  # update pprof image version below as well
+appVersion: "1.34.0"  # update pprof image version below as well
 annotations:
   artifacthub.io/images: |-
     - name: cray-bss-pprof
-      image: artifactory.algol60.net/csm-docker/stable/cray-bss-pprof:1.32.0
+      image: artifactory.algol60.net/csm-docker/stable/cray-bss-pprof:1.34.0
   artifacthub.io/license: "MIT"

--- a/charts/v3.3/cray-hms-bss/values.yaml
+++ b/charts/v3.3/cray-hms-bss/values.yaml
@@ -11,8 +11,8 @@
 # See https://connect.us.cray.com/jira/browse/CASMCLOUD-661
 
 global:
-  appVersion: 1.33.0
-  testVersion: 1.33.0
+  appVersion: 1.34.0
+  testVersion: 1.34.0
 
 image:
   repository: artifactory.algol60.net/csm-docker/stable/cray-bss

--- a/cray-hms-bss.compatibility.yaml
+++ b/cray-hms-bss.compatibility.yaml
@@ -56,6 +56,7 @@ chartVersionToApplicationVersion:
   "3.3.1": "1.32.0"
   "3.3.2": "1.33.0"
   "3.3.3": "1.33.0"
+  "3.3.4": "1.34.0"
 
 # Test results for combinations of Chart, Application, and CSM versions.
 chartValidationLog: []


### PR DESCRIPTION
### Summary and Scope

Updated all module and image dependencies to latest versions.  The primary reason for this was to pick up some resource leak fixes to the HMS module dependencies.

Updated Go to v1.24.

Used hms-base APIs for explicitly draining and closing http request and response bodies.

Fixed a bug with jq use when running runSnyk.sh

Adopted app version 1.34.0 for CSM 1.7.0 (helm chart 3.3.4).

### Issues and Related PRs

* Resolves [CASMHMS-6389](https://jira-pro.it.hpe.com:8443/browse/CASMHMS-6389)

### Testing

Tested on:

* `mug`

Test description:

Upgraded to dev version of service.  Watched log files to ensure nothing obvious was wrong.  Verified all CT tests still pass.

Note that testing used the stable 3.3.2 helm chart as 3.3.3 and later are unable to be deployed on mug.

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable