### PR TITLE
CASMHMS-6602: Update BSS dependencies

### DIFF
--- a/.github/workflows/k8s_api_checker.yaml
+++ b/.github/workflows/k8s_api_checker.yaml
@@ -2,5 +2,5 @@ name: Kubernetes API Checker
 on: [push, pull_request, workflow_dispatch]
 jobs:
   k8s_api_checker:
-    uses: Cray-HPE/hms-build-chart-workflows/.github/workflows/k8s_api_checker.yaml@v2
+    uses: Cray-HPE/hms-build-chart-workflows/.github/workflows/k8s_api_checker.yaml@v4
     secrets: inherit

--- a/changelog/v3.3.md
+++ b/changelog/v3.3.md
@@ -5,6 +5,13 @@ All notable changes to this project for v3.3.Z will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.3.5] - 2025-09-26
+
+- Updated Alpine base image to pick up security fixes
+- Updated HMS image and Go module version dependencies
+- Updated k8s_api_checker.yaml from v2 to v4
+- Internal tracking ticket: CASMHMS-6602
+
 ## [3.3.4] - 2025-05-28
 
 ### Updated

--- a/charts/v3.3/cray-hms-bss/Chart.yaml
+++ b/charts/v3.3/cray-hms-bss/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: "cray-hms-bss"
-version: 3.3.4
+version: 3.3.5
 description: "Kubernetes resources for cray-hms-bss"
 home: "https://github.com/Cray-HPE/hms-bss-charts"
 sources:
@@ -15,9 +15,9 @@ dependencies:
 maintainers:
   - name: Hardware Management
     url: https://github.com/orgs/Cray-HPE/teams/hardware-management
-appVersion: "1.34.0"  # update pprof image version below as well
+appVersion: "1.35.0"  # update pprof image version below as well
 annotations:
   artifacthub.io/images: |-
     - name: cray-bss-pprof
-      image: artifactory.algol60.net/csm-docker/stable/cray-bss-pprof:1.34.0
+      image: artifactory.algol60.net/csm-docker/stable/cray-bss-pprof:1.35.0
   artifacthub.io/license: "MIT"

--- a/charts/v3.3/cray-hms-bss/values.yaml
+++ b/charts/v3.3/cray-hms-bss/values.yaml
@@ -11,8 +11,8 @@
 # See https://connect.us.cray.com/jira/browse/CASMCLOUD-661
 
 global:
-  appVersion: 1.34.0
-  testVersion: 1.34.0
+  appVersion: 1.35.0
+  testVersion: 1.35.0
 
 image:
   repository: artifactory.algol60.net/csm-docker/stable/cray-bss

--- a/cray-hms-bss.compatibility.yaml
+++ b/cray-hms-bss.compatibility.yaml
@@ -57,6 +57,7 @@ chartVersionToApplicationVersion:
   "3.3.2": "1.33.0"
   "3.3.3": "1.33.0"
   "3.3.4": "1.34.0"
+  "3.3.5": "1.35.0"
 
 # Test results for combinations of Chart, Application, and CSM versions.
 chartValidationLog: []


### PR DESCRIPTION
### Summary and Scope

Updated Alpine base image from 3.21 to 3.22 to pick up security fixes.

Updated all of the HMS and Go module image dependencies.

Also updated chart build usage of k8s_api_checker.yaml workflow from v2 to v4 because we were having build issues.

Adopted app version 1.35.0 for CSM 1.7.1 (helm chart 3.3.5)

### Issues and Related PRs

* Resolves [CASMHMS-6602](https://jira-pro.it.hpe.com:8443/browse/CASMHMS-6602)

### Testing

Tested via pipeline execution of CT tests and on system mug.

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] Testing is appropriate and complete, if applicable