### PR TITLE
CASMHMS-6614: Updated BSS to point to latest SMD v2.44.0 image

### DIFF
--- a/changelog/v3.3.md
+++ b/changelog/v3.3.md
@@ -5,6 +5,13 @@ All notable changes to this project for v3.3.Z will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.3.7] - 2025-11-18
+
+### Fixed
+
+- Updated BSS to point to latest SMD v2.44.0 image
+- Internal tracking ticket: CASMHMS-6614
+
 ## [3.3.6] - 2025-11-04
 
 ### Fixed

--- a/charts/v3.3/cray-hms-bss/Chart.yaml
+++ b/charts/v3.3/cray-hms-bss/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: "cray-hms-bss"
-version: 3.3.6
+version: 3.3.7
 description: "Kubernetes resources for cray-hms-bss"
 home: "https://github.com/Cray-HPE/hms-bss-charts"
 sources:
@@ -15,9 +15,9 @@ dependencies:
 maintainers:
   - name: Hardware Management
     url: https://github.com/orgs/Cray-HPE/teams/hardware-management
-appVersion: "1.36.0"  # update pprof image version below as well
+appVersion: "1.37.0"  # update pprof image version below as well
 annotations:
   artifacthub.io/images: |-
     - name: cray-bss-pprof
-      image: artifactory.algol60.net/csm-docker/stable/cray-bss-pprof:1.36.0
+      image: artifactory.algol60.net/csm-docker/stable/cray-bss-pprof:1.37.0
   artifacthub.io/license: "MIT"

--- a/charts/v3.3/cray-hms-bss/values.yaml
+++ b/charts/v3.3/cray-hms-bss/values.yaml
@@ -11,8 +11,8 @@
 # See https://connect.us.cray.com/jira/browse/CASMCLOUD-661
 
 global:
-  appVersion: 1.36.0
-  testVersion: 1.36.0
+  appVersion: 1.37.0
+  testVersion: 1.37.0
 
 image:
   repository: artifactory.algol60.net/csm-docker/stable/cray-bss

--- a/cray-hms-bss.compatibility.yaml
+++ b/cray-hms-bss.compatibility.yaml
@@ -60,6 +60,7 @@ chartVersionToApplicationVersion:
   "3.3.4": "1.34.0"
   "3.3.5": "1.35.0"
   "3.3.6": "1.36.0"
+  "3.3.7": "1.37.0"
 
 # Test results for combinations of Chart, Application, and CSM versions.
 chartValidationLog: []


### PR DESCRIPTION
### Summary and Scope

Updated BSS to point to latest SMD v2.44.0 image

Adopted app version 3.3.7 for CSM 1.7.1 (helm chart 1.36.0)

### Issues and Related PRs

* Resolves [CASMHMS-6614](https://jira-pro.it.hpe.com:8443/browse/CASMHMS-6614)

### Testing

Tested on:

* `mug`

- Deployed on mug and watched logs to ensure no adverse logs were being made
- Ran BSS CT tests on mug and verified there were no failures

### Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable